### PR TITLE
Feat: eliminate LEDGER_DB_SYNC

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,11 +34,8 @@ npm install
 To run it using an in-memory database (the simplest option), run:
 
 ``` sh
-LEDGER_ADMIN_PASS=mypassword LEDGER_DB_SYNC=1 LEDGER_DB_URI=sqlite://:memory: npm start
+LEDGER_ADMIN_PASS=mypassword LEDGER_DB_URI=sqlite://:memory: npm start
 ```
-
-Note: `LEDGER_DB_SYNC` runs a SQL script to setup the database schema and
-should only be set when running for the first time on a particular database.
 
 Or run:
 
@@ -92,5 +89,5 @@ npm test
 ```
 If you wish to specify the database against which the tests are run, use the `LEDGER_UNIT_DB_URI` environment variable.
 ``` sh
-LEDGER_DB_SYNC=1 LEDGER_UNIT_DB_URI=postgres://root:password@localhost:5432/ledger_test_db npm test
+LEDGER_UNIT_DB_URI=postgres://root:password@localhost:5432/ledger_test_db npm test
 ```

--- a/docs/apidoc_intro.ejs.md
+++ b/docs/apidoc_intro.ejs.md
@@ -88,7 +88,6 @@ The Five Bells Ledger supports two kinds of authentication: HTTP Basic, or clien
 Use the following environment variables to configure the service when run:
 
 * `LEDGER_DB_URI` (required; e.g.: `mysql://root:password@localhost/fivebells`) URI for connecting to a database. Defaults to `sqlite` if no database is set.
-* `LEDGER_DB_SYNC` (default: `0`) whether or not to run the SQL setup scripts for the database
 * `LEDGER_PORT` (default: `3000`) Port that Five Bells Ledger will listen on.
 * `LEDGER_BIND_IP` (default: `0.0.0.0`) IP that Five Bells Ledger will bind to.
 * `LEDGER_PUBLIC_URI` (default: `http://$HOSTNAME:$LEDGER_PORT`) URI prefix where the ledger will be publicly visible. All IDs and URIs that that the ledger outputs will be using this root URI.

--- a/src/lib/app.js
+++ b/src/lib/app.js
@@ -67,9 +67,13 @@ class App {
     // when transfers are going to expire
     yield this.timerWorker.start()
 
-    if (this.config.getIn(['db', 'sync'])) {
+    try {
+      this.log.info('syncing database')
       yield createTables()
+    } catch (e) {
+      this.log.info('database sync aborted')
     }
+
     yield readLookupTables()
     yield seedDB(this.config)
 


### PR DESCRIPTION
If the database has already been created, then the `create.sql` script run by `createTables` will throw an error without doing anything. This removes the need to run the first time with `LEDGER_DB_SYNC=1`, and run subsequent times with it unset.