### PR TITLE
Use integration test loader

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "docs": "npm run docs:prep-intro && npm run docs:apidoc",
     "docs:prep-intro": "scripts/build_docs.js",
     "docs:apidoc": "apidoc -o apidoc-out -i src/controllers/",
-    "integration": "integration all",
+    "integration": "integration-loader && integration all",
     "bump": "version-bump"
   },
   "engines": {
@@ -79,7 +79,7 @@
     "eslint": "^2.0.0",
     "eslint-config-standard": "^5.1.0",
     "eslint-plugin-promise": "^1.1.0",
-    "five-bells-integration-test": "^5.0.0",
+    "five-bells-integration-test-loader": "^1.0.0",
     "istanbul": "0.4.0",
     "mocha": "~2.3.4",
     "nock": "^2.10.0",
@@ -89,5 +89,11 @@
     "supertest": "^2.0.1",
     "through2": "^2.0.1",
     "ws": "^1.1.0"
+  },
+  "config": {
+    "five-bells-integration-test-loader": {
+      "module": "five-bells-integration-test",
+      "repo": "interledgerjs/five-bells-integration-test"
+    }
   }
 }


### PR DESCRIPTION
Currently, we have to bump the version of integration tests on every module, every time we change them. We also often get into deadlocks we have to resolve by skipping tests.

This is part of a series of pull requests to switch to five-bells-integration-test-loader, which will solve both problems by loading the integration tests according to the same rules as other modules: Use latest master, unless there is a branch of the same name, then use that branch.

It's probably easiest to understand by looking at the following two links:
* b241d14768b02a42a34dc42e91d5101db7de0525
* https://github.com/interledgerjs/five-bells-integration-test-loader