### PR TITLE
fix: Check expiry date before fulfilling a transfer

### DIFF
--- a/src/models/transfers.js
+++ b/src/models/transfers.js
@@ -395,6 +395,7 @@ function * fulfillTransfer (transferId, fulfillmentUri) {
     }
 
     const conditionType = validateConditionFulfillment(transfer, fulfillment)
+    transferExpiryMonitor.validateNotExpired(transfer)
 
     if (
       conditionType === CONDITION_TYPE_EXECUTION &&


### PR DESCRIPTION
Before fulfilling a transfer, the ledger did not check if the transfer was expired. This has several

securtiy-critical consequences, e.g.: An attacker can bring a connector to put funds on hold and

trick the ledger to fulfill the hold after it is expired. In this scenario, the connector can not

pass on the fulfillment in time to the source ledger and, thus, losses the funds.