### PR TITLE
Only send one notification, even if two subscribed accounts are involved in a transfer

### DIFF
--- a/src/lib/notificationBroadcasterWebsocket.js
+++ b/src/lib/notificationBroadcasterWebsocket.js
@@ -70,6 +70,16 @@ class NotificationBroadcaster extends EventEmitter {
     }
     return isDelivered
   }
+
+  addNotificationListener (accountName, eventType, listener) {
+    const eventName = 'notification:' + accountName + ':' + eventType
+    this.addListener(eventName, listener)
+  }
+
+  removeNotificationListener (accountName, eventType, listener) {
+    const eventName = 'notification:' + accountName + ':' + eventType
+    this.removeListener(eventName, listener)
+  }
 }
 
 module.exports = NotificationBroadcaster

--- a/src/lib/rpcHandler.js
+++ b/src/lib/rpcHandler.js
@@ -77,12 +77,9 @@ class RpcHandler {
     this.removeAccountSubscriptions()
 
     for (const accountName of accountNames) {
-      const eventName = 'notification:' + accountName + ':' + eventType
-      this.log.info('new ws subscriber for ' + eventName)
-      this.notificationBroadcaster.addListener(eventName, this.sendNotification)
-      this.websocket.on('close', () =>
-        this.notificationBroadcaster.removeListener(eventName, this.sendNotification))
-      this.accountSubscriptions.push(eventName)
+      this.log.info('new ws subscriber for ' + accountName + ':' + eventType)
+      this.notificationBroadcaster.addNotificationListener(accountName, eventType, this.sendNotification)
+      this.accountSubscriptions.push({ accountName, eventType })
     }
 
     // Updated number of active account subscriptions on this WebSocket connection.
@@ -95,8 +92,10 @@ class RpcHandler {
   }
 
   removeAccountSubscriptions () {
-    for (const eventName of this.accountSubscriptions) {
-      this.notificationBroadcaster.removeListener(eventName, this.sendNotification)
+    for (const eventInfo of this.accountSubscriptions) {
+      this.notificationBroadcaster.removeNotificationListener(
+        eventInfo.accountName, eventInfo.eventType, this.sendNotification
+      )
     }
     this.accountSubscriptions = []
   }


### PR DESCRIPTION
As the title says, fixes #385.

The implementation works by replacing EventEmitter with a custom dispatcher using JavaScript's built-in Map/Set primitives.

Add basic tests for admin (3rd party) subscriptions and a regression test for #385.