### PR TITLE
fix: fix misc. logging issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "koa-cors": "0.0.16",
     "koa-mag": "^1.0.4",
     "koa-passport": "^1.1.6",
-    "koa-riverpig": "^1.0.0",
+    "koa-riverpig": "^1.0.1",
     "koa-router": "^5.1.2",
     "koa-static": "^2.0.0",
     "lodash": "^4.16.4",

--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -116,10 +116,12 @@ function migratePostgres (step) {
     const args = [config.db.uri]
     if (step) args.push(step)
     const childProcess = spawn('pg-migrator', args, {cwd: path.resolve(sqlDir, 'pg')})
+    let error = ''
     childProcess.on('error', reject)
+    childProcess.stderr.on('data', (data) => { error += data.toString() })
     childProcess.on('close', (code) => {
       return code === 0 ? resolve() : reject(
-        new Error('pg-migrator exited with code ' + code))
+        new Error('pg-migrator exited with code ' + code + ' stderr: ' + error))
     })
   })
 }


### PR DESCRIPTION
* Don't use `logger` for websocket connections, it tries to attach events to `this.res`, which doesn't exist.
* More detailed logging when pg-migrator fails.