### PR TITLE
perf: Change default scale,precision to 10 digits before the comma, 9 after

### DIFF
--- a/src/lib/config.js
+++ b/src/lib/config.js
@@ -17,8 +17,8 @@ function useTestConfig () {
 
 function parseAmountConfig () {
   return {
-    precision: parseInt(Config.getEnv(envPrefix, 'AMOUNT_PRECISION'), 10) || 10,
-    scale: parseInt(Config.getEnv(envPrefix, 'AMOUNT_SCALE'), 10) || 2
+    precision: parseInt(Config.getEnv(envPrefix, 'AMOUNT_PRECISION'), 10) || 19,
+    scale: parseInt(Config.getEnv(envPrefix, 'AMOUNT_SCALE'), 10) || 9
   }
 }
 

--- a/test/configSpec.js
+++ b/test/configSpec.js
@@ -119,8 +119,8 @@ describe('loadConfig', () => {
 
   describe('config.amount', () => {
     const defaults = {
-      precision: 10,
-      scale: 2
+      precision: 19,
+      scale: 9
     }
 
     it('returns default amount config when no env vars set', () => {
@@ -128,10 +128,10 @@ describe('loadConfig', () => {
       expect(_config.amount).to.deep.equal(defaults)
     })
 
-    it('LEDGER_AMOUNT_SCALE=10', () => {
-      process.env.LEDGER_AMOUNT_SCALE = '10'
+    it('LEDGER_AMOUNT_SCALE=7', () => {
+      process.env.LEDGER_AMOUNT_SCALE = '7'
       const amount = _.defaults({
-        scale: 10
+        scale: 7
       }, defaults)
       const _config = loadConfig()
       expect(_config.amount).to.deep.equal(amount)

--- a/test/metadataSpec.js
+++ b/test/metadataSpec.js
@@ -42,8 +42,8 @@ describe('Metadata', function () {
               websocket: 'ws://localhost/websocket',
               message: 'http://localhost/messages'
             },
-            precision: 10,
-            scale: 2,
+            precision: 19,
+            scale: 9,
             connectors: []
           })
         })
@@ -88,8 +88,8 @@ describe('Metadata', function () {
               websocket: 'ws://localhost/websocket',
               message: 'http://localhost/messages'
             },
-            precision: 10,
-            scale: 2,
+            precision: 19,
+            scale: 9,
             connectors: [
               {
                 id: 'http://localhost/accounts/trader',

--- a/test/putTransferSpec.js
+++ b/test/putTransferSpec.js
@@ -132,10 +132,10 @@ describe('PUT /transfers/:id', function () {
   })
 
   it('should return 422 if the sender amount precision is too high', function * () {
-    assert.strictEqual(config.amount.precision, 10) // default precision is 10
+    assert.strictEqual(config.amount.precision, 19) // default precision is 19
     const transfer = this.exampleTransfer
-    transfer.debits[0].amount = '100000000.23'
-    transfer.credits[0].amount = '100000000.23'
+    transfer.debits[0].amount = '991234567890.123456789'
+    transfer.credits[0].amount = '991234567890.123456789'
     yield this.request()
       .put(transfer.id)
       .auth('bob', 'bob')
@@ -145,10 +145,10 @@ describe('PUT /transfers/:id', function () {
   })
 
   it('should return 422 if the sender amount scale is too high', function * () {
-    assert.strictEqual(config.amount.scale, 2) // default scale is 2
+    assert.strictEqual(config.amount.scale, 9) // default scale is 9
     const transfer = this.exampleTransfer
-    transfer.debits[0].amount = '1.123'
-    transfer.credits[0].amount = '1.123'
+    transfer.debits[0].amount = '1.1234567899'
+    transfer.credits[0].amount = '1.1234567899'
     yield this.request()
       .put(transfer.id)
       .auth('bob', 'bob')


### PR DESCRIPTION
if the currency is for instance dollars, precision will now be nanodollars, and maximum balance will
be 10 billion dollars