### PR TITLE
feat: Announce API version in metadata

### DIFF
--- a/src/controllers/metadata.js
+++ b/src/controllers/metadata.js
@@ -6,7 +6,7 @@ const accounts = require('../models/accounts')
  * @api {get} / Get Server Metadata
  * @apiName GetMetadata
  * @apiGroup Metadata Methods
- * @apiVersion 1.0.0
+ * @version 1.0.0
  *
  * @apiDescription This endpoint will return server metadata.
  * @apiExample {shell} Get Metadata
@@ -72,6 +72,11 @@ module.exports = (config) => {
     },
     precision: config.get('amount.precision'),
     scale: config.get('amount.scale')
+  }
+
+  try {
+    metadata.version = `five-bells@${require('../../package.json').version.split('.')[0]}`
+  } catch (e) {
   }
 
   return {

--- a/test/metadataSpec.js
+++ b/test/metadataSpec.js
@@ -42,6 +42,7 @@ describe('Metadata', function () {
               websocket: 'ws://localhost/websocket',
               message: 'http://localhost/messages'
             },
+            version: 'five-bells@20',
             precision: 19,
             scale: 9,
             connectors: []
@@ -88,6 +89,7 @@ describe('Metadata', function () {
               websocket: 'ws://localhost/websocket',
               message: 'http://localhost/messages'
             },
+            version: 'five-bells@20',
             precision: 19,
             scale: 9,
             connectors: [


### PR DESCRIPTION
There is currently no way to know which version a ledger is running, other than if the ledger was discovered through an ilp-kit WebFinger record. Adding this, fixes that.