### PR TITLE
feat: Adds authentication to all endpoints under /transfers/*

### DIFF
--- a/src/lib/app.js
+++ b/src/lib/app.js
@@ -132,15 +132,23 @@ class App {
       setupBody,
       transfers.putResource)
 
-    router.put('/transfers/:id/fulfillment', transfers.putFulfillment)
-    router.get('/transfers/:id/fulfillment', transfers.getFulfillment)
+    router.put('/transfers/:id/fulfillment',
+      passport.authenticate(['basic', 'http-signature', 'client-cert'], { session: false }),
+      transfers.putFulfillment)
+    router.get('/transfers/:id/fulfillment',
+      passport.authenticate(['basic', 'http-signature', 'client-cert'], { session: false }),
+      transfers.getFulfillment)
     router.put('/transfers/:id/rejection',
       passport.authenticate(['basic', 'http-signature', 'client-cert'], { session: false }),
       setupBody,
       transfers.putRejection)
 
-    router.get('/transfers/:id', transfers.getResource)
-    router.get('/transfers/:id/state', transfers.getStateResource)
+    router.get('/transfers/:id',
+      passport.authenticate(['basic', 'http-signature', 'client-cert'], { session: false }),
+      transfers.getResource)
+    router.get('/transfers/:id/state',
+      passport.authenticate(['basic', 'http-signature', 'client-cert'], { session: false }),
+      transfers.getStateResource)
 
     router.get('/accounts',
       passport.authenticate(['basic', 'http-signature', 'client-cert'], { session: false }),

--- a/test/fulfillmentSpec.js
+++ b/test/fulfillmentSpec.js
@@ -48,6 +48,13 @@ describe('GET /fulfillment', function () {
     this.clock.restore()
   })
 
+  it('should return 401 if the request is not authenticated', function * () {
+    yield this.request()
+        .get(this.executedTransfer.id + '/fulfillment')
+        .expect(401)
+        .end()
+  })
+
   /* GET fulfillments */
   it('should return 404 for fulfillment when given an invalid transfer id', function * () {
     yield this.request()
@@ -87,6 +94,7 @@ describe('GET /fulfillment', function () {
 
     yield this.request()
       .put(transfer.id + '/fulfillment')
+      .auth('admin', 'admin')
       .send(this.executionConditionFulfillment)
       .expect(422)
       .expect({
@@ -155,6 +163,7 @@ describe('GET /fulfillment', function () {
 
     yield this.request()
       .put(transfer.id + '/fulfillment')
+      .auth('admin', 'admin')
       .send(this.executionConditionFulfillment)
       .expect(201)
       .expect(this.executionConditionFulfillment)
@@ -177,6 +186,7 @@ describe('GET /fulfillment', function () {
 
     yield this.request()
       .put(transfer.id + '/fulfillment')
+      .auth('admin', 'admin')
       .send(this.executionConditionFulfillment)
       .expect(400)
       .end()
@@ -187,6 +197,7 @@ describe('GET /fulfillment', function () {
 
     yield this.request()
       .put(transfer.id + '/fulfillment')
+      .auth('admin', 'admin')
       .send(this.cancellationConditionFulfillment)
       .expect(400)
       .end()
@@ -199,6 +210,7 @@ describe('GET /fulfillment', function () {
 
     yield this.request()
       .put(transfer.id + '/fulfillment')
+      .auth('admin', 'admin')
       .send(executionConditionFulfillment)
       .expect(422)
       .end()
@@ -235,10 +247,18 @@ describe('PUT /fulfillment', function () {
     this.clock.restore()
   })
 
+  it('should return 401 if the request is not authenticated', function * () {
+    yield this.request()
+      .put(this.preparedTransfer.id + '/fulfillment')
+      .expect(401)
+      .end()
+  })
+
   it('should return 404 when fulfilling a non-existent transfer', function * () {
     const transfer = this.preparedTransfer
     yield this.request()
       .put(transfer.id + '/fulfillment')
+      .auth('admin', 'admin')
       .send(this.executionConditionFulfillment)
       .expect(404)
       .end()
@@ -263,6 +283,7 @@ describe('PUT /fulfillment', function () {
 
     yield this.request()
       .put(transfer.id + '/fulfillment')
+      .auth('alice', 'alice')
       .send(this.cancellationConditionFulfillment)
       .expect(422)
       .expect({
@@ -293,6 +314,7 @@ describe('PUT /fulfillment', function () {
       const invalidCancellationConditionFulfillment = 'oAiABp6LXGp3Hg'
       yield this.request()
         .put(transfer.id + '/fulfillment')
+        .auth('alice', 'alice')
         .send(invalidCancellationConditionFulfillment)
         .expect(422)
         .expect({
@@ -307,6 +329,7 @@ describe('PUT /fulfillment', function () {
 
       yield this.request()
         .put(transfer.id + '/fulfillment')
+        .auth('alice', 'alice')
         .send(this.cancellationConditionFulfillment)
         .expect(201)
         .expect(this.cancellationConditionFulfillment)
@@ -334,6 +357,7 @@ describe('PUT /fulfillment', function () {
 
       yield this.request()
         .put(transfer.id + '/fulfillment')
+        .auth('alice', 'alice')
         .send(this.executionConditionFulfillment)
         .expect(201)
         .expect(this.executionConditionFulfillment)
@@ -359,6 +383,7 @@ describe('PUT /fulfillment', function () {
 
       yield this.request()
         .put(transfer.id + '/fulfillment')
+        .auth('alice', 'alice')
         .send(this.executionConditionFulfillmentTypeAnd)
         .expect(201)
         .expect(this.executionConditionFulfillmentTypeAnd)
@@ -391,16 +416,19 @@ describe('PUT /fulfillment', function () {
     yield [
       this.request()
         .put(transfer.id + '/fulfillment')
+        .auth('alice', 'alice')
         .send(this.executionConditionFulfillment)
         .expect(validateResponse)
         .end(),
       this.request()
         .put(transfer.id + '/fulfillment')
+        .auth('alice', 'alice')
         .send(this.executionConditionFulfillment)
         .expect(validateResponse)
         .end(),
       this.request()
         .put(transfer.id + '/fulfillment')
+        .auth('alice', 'alice')
         .send(this.executionConditionFulfillment)
         .expect(validateResponse)
         .end()
@@ -429,6 +457,7 @@ describe('PUT /fulfillment', function () {
 
     yield this.request()
       .put(transfer.id + '/fulfillment')
+      .auth('alice', 'alice')
       .send(this.cancellationConditionFulfillment)
       .expect(201)
       .expect(this.cancellationConditionFulfillment)
@@ -441,6 +470,7 @@ describe('PUT /fulfillment', function () {
 
     yield this.request()
       .put(transfer.id + '/fulfillment')
+      .auth('alice', 'alice')
       .send(this.cancellationConditionFulfillment)
       .expect(422)
       .expect({

--- a/test/getTransferSpec.js
+++ b/test/getTransferSpec.js
@@ -53,6 +53,7 @@ describe('GET /transfers/:uuid', function () {
     const transfer = this.existingTransfer
     yield this.request()
       .get(transfer.id)
+      .auth('alice', 'alice')
       .expect(200)
       .expect(transfer)
       .expect(validator.validateTransfer)
@@ -62,7 +63,15 @@ describe('GET /transfers/:uuid', function () {
   it('should return 404 when the transfer does not exist', function * () {
     yield this.request()
       .get(this.exampleTransfer.id)
+      .auth('admin', 'admin')
       .expect(404)
+      .end()
+  })
+
+  it('should return 401 if the request is not authenticated', function * () {
+    yield this.request()
+      .get(this.exampleTransfer.id)
+      .expect(401)
       .end()
   })
 
@@ -86,6 +95,7 @@ describe('GET /transfers/:uuid', function () {
 
     yield this.request()
       .get(transfer.id)
+      .auth('alice', 'alice')
       .expect(200, _.assign({}, transfer, {
         state: transferStates.TRANSFER_STATE_REJECTED,
         rejection_reason: 'expired',

--- a/test/notificationSpec.js
+++ b/test/notificationSpec.js
@@ -182,6 +182,7 @@ describe('Notifications', function () {
         this.clock.tick(500)
         yield this.request()
           .put(transfer.id + '/fulfillment')
+          .auth('alice', 'alice')
           .send(fulfillment)
           .expect(201)
           .end()
@@ -343,6 +344,7 @@ describe('Notifications', function () {
 
         yield this.request()
           .put(transfer.id + '/fulfillment')
+          .auth('alice', 'alice')
           .send(this.executionConditionFulfillment)
           .expect(201)
           .expect(this.executionConditionFulfillment)
@@ -410,6 +412,7 @@ describe('Notifications', function () {
 
         yield this.request()
           .put(transfer.id + '/fulfillment')
+          .auth('alice', 'alice')
           .send(this.cancellationConditionFulfillment)
           .expect(201)
           .expect(this.cancellationConditionFulfillment)

--- a/test/rejectionSpec.js
+++ b/test/rejectionSpec.js
@@ -56,6 +56,13 @@ describe('PUT /rejection', function () {
     this.clock.restore()
   })
 
+  it('should return 401 if the request is not authenticated', function * () {
+    yield this.request()
+      .put(this.preparedTransfer.id + '/rejection')
+      .expect(401)
+      .end()
+  })
+
   it('should return 404 when rejecting a non-existent transfer', function * () {
     const transfer = this.preparedTransfer
     yield this.request()
@@ -127,6 +134,7 @@ describe('PUT /rejection', function () {
 
     yield this.request()
       .get(transfer.id)
+      .auth('alice', 'alice')
       .expect(200)
       .expect(Object.assign(transfer, {
         state: 'rejected',
@@ -182,6 +190,7 @@ describe('PUT /rejection', function () {
 
     yield this.request()
       .get(transfer.id)
+      .auth('alice', 'alice')
       .expect(200)
       .expect(Object.assign(transfer, {
         state: 'rejected',

--- a/test/transferStateSpec.js
+++ b/test/transferStateSpec.js
@@ -50,6 +50,13 @@ describe('Transfer State', function () {
   })
 
   describe('GET /transfers/:uuid/state', function () {
+    it('should return 401 if the request is not authenticated', function * () {
+      yield this.request()
+        .get(this.transferWithExpiry.id)
+        .expect(401)
+        .end()
+    })
+
     it('should return a 200 if the transfer does not exist', function * () {
       const stateReceipt = {
         id: 'http://localhost/transfers/03b7c787-e104-4390-934e-693072c6eda2',
@@ -65,6 +72,7 @@ describe('Transfer State', function () {
 
       yield this.request()
         .get('/transfers/03b7c787-e104-4390-934e-693072c6eda2/state')
+        .auth('admin', 'admin')
         .expect(200, {
           message: stateReceipt,
           type: 'ed25519-sha512',
@@ -104,6 +112,7 @@ describe('Transfer State', function () {
 
       yield this.request()
         .get(transfer.id + '/state?type=sha256')
+        .auth('alice', 'alice')
         .expect(200, {
           message: stateReceipt,
           type: 'sha256',
@@ -149,6 +158,7 @@ describe('Transfer State', function () {
 
       yield this.request()
         .get(transfer.id + '/state?type=sha256&condition_state=executed')
+        .auth('alice', 'alice')
         .expect(200, {
           message: stateReceipt,
           type: 'sha256',
@@ -168,6 +178,7 @@ describe('Transfer State', function () {
     it('returns 400 if the ?type parameter is invalid', function * () {
       yield this.request()
         .get(this.executedTransfer.id + '/state?type=bogus')
+        .auth('alice', 'alice')
         .expect(400, {
           id: 'InvalidUriParameterError',
           message: 'type is not valid'
@@ -193,6 +204,7 @@ describe('Transfer State', function () {
 
       yield this.request()
         .get(this.executedTransfer.id + '/state')
+        .auth('alice', 'alice')
         .expect(200, {
           message: stateReceipt,
           type: 'ed25519-sha512',
@@ -225,6 +237,7 @@ describe('Transfer State', function () {
 
         yield this.request()
           .get(transfer.id + '/state')
+          .auth('alice', 'alice')
           .expect(200, {
             message: stateReceipt,
             type: 'ed25519-sha512',
@@ -243,6 +256,7 @@ describe('Transfer State', function () {
 
       yield this.request()
         .get(transfer.id + '/state')
+        .auth('alice', 'alice')
         .expect(function (res) {
           let validationResult = validate('TransferStateReceipt', res.body)
           if (!validationResult.valid) {
@@ -285,6 +299,7 @@ describe('Transfer State', function () {
 
       yield this.request()
         .get(transfer.id + '/state')
+        .auth('alice', 'alice')
         .expect(200, {
           message: stateReceipt,
           type: 'ed25519-sha512',


### PR DESCRIPTION
- feat: Adds authentication to all endpoints under /transfers/*
- test: changes requests to /transfers/* to use basic auth
- test: validates that requests to /transfers/* have to be authenticated