### PR TITLE
fix: use correct pg-migrator path, no matter where it is

### DIFF
--- a/src/lib/db.js
+++ b/src/lib/db.js
@@ -14,6 +14,12 @@ const readRejectionReasons = require('../models/db/rejectionReasons')
 const readTransferStatuses = require('../models/db/transferStatuses')
   .readTransferStatuses
 const config = require('../services/config')
+const pgMigratorPackageJson = require('pg-migrator/package.json')
+const pgMigratorPackageJsonPath = require.resolve('pg-migrator/package.json')
+const pgMigratorBinPath = path.resolve(
+  path.dirname(pgMigratorPackageJsonPath),
+  pgMigratorPackageJson.bin['pg-migrator']
+)
 const sqlDir = path.resolve(__dirname, '..', 'sql')
 const log = require('../services/log').create('db')
 
@@ -135,7 +141,7 @@ function migratePostgres (step) {
   return new Promise((resolve, reject) => {
     const args = [config.db.uri]
     if (step) args.push(step)
-    const childProcess = spawn('pg-migrator', args, {cwd: path.resolve(sqlDir, 'pg')})
+    const childProcess = spawn(pgMigratorBinPath, args, {cwd: path.resolve(sqlDir, 'pg')})
     let error = ''
     childProcess.on('error', reject)
     childProcess.stderr.on('data', (data) => { error += data.toString() })


### PR DESCRIPTION
Currently, when using five-bells-ledger as a dependency you may get this error:

```
[ledger] 2017-05-10T23:19:48.020Z ledger:app error error: relation "L_LU_REJECTION_REASON" does not exist
[ledger]     at Connection.parseE (/opt/workspace/interledgerjs/ilp-kit/node_modules/pg/lib/connection.js:539:11)
[ledger]     at Connection.parseMessage (/opt/workspace/interledgerjs/ilp-kit/node_modules/pg/lib/connection.js:366:17)
[ledger]     at Socket.<anonymous> (/opt/workspace/interledgerjs/ilp-kit/node_modules/pg/lib/connection.js:105:22)
[ledger]     at emitOne (events.js:96:13)
[ledger]     at Socket.emit (events.js:191:7)
[ledger]     at readableAddChunk (_stream_readable.js:178:18)
[ledger]     at Socket.Readable.push (_stream_readable.js:136:10)
[ledger]     at TCP.onread (net.js:561:20)
[ledger] From previous event:
[ledger]     at Client_PG._query (/opt/workspace/interledgerjs/ilp-kit/node_modules/knex/lib/dialects/postgres/index.js:235:12)
[ledger]     at Client_PG.query (/opt/workspace/interledgerjs/ilp-kit/node_modules/knex/lib/client.js:197:17)
[ledger]     at Runner.<anonymous> (/opt/workspace/interledgerjs/ilp-kit/node_modules/knex/lib/runner.js:146:36)
[ledger] From previous event:
[ledger]     at /opt/workspace/interledgerjs/ilp-kit/node_modules/knex/lib/runner.js:65:21
[ledger]     at runCallback (timers.js:672:20)
[ledger]     at tryOnImmediate (timers.js:645:5)
[ledger]     at processImmediate [as _immediateCallback] (timers.js:617:5)
[ledger] From previous event:
[ledger]     at Runner.run (/opt/workspace/interledgerjs/ilp-kit/node_modules/knex/lib/runner.js:51:31)
[ledger]     at Builder.Target.then (/opt/workspace/interledgerjs/ilp-kit/node_modules/knex/lib/interface.js:35:43)
[ledger]     at readRejectionReasons (/opt/workspace/interledgerjs/ilp-kit/node_modules/five-bells-ledger/src/models/db/rejectionReasons.js:11:36)
[ledger]     at readLookupTables (/opt/workspace/interledgerjs/ilp-kit/node_modules/five-bells-ledger/src/lib/db.js:153:23)
[ledger]     at App._start (/opt/workspace/interledgerjs/ilp-kit/node_modules/five-bells-ledger/src/lib/app.js:79:11)
[ledger]     at _start.throw (<anonymous>)
[ledger]     at onRejected (/opt/workspace/interledgerjs/ilp-kit/node_modules/co/index.js:81:24)
[ledger]     at process._tickCallback (internal/process/next_tick.js:109:7)
[ledger]     at Module.runMain (module.js:607:11)
[ledger]     at run (bootstrap_node.js:427:7)
[ledger]     at startup (bootstrap_node.js:151:9)
[ledger]     at bootstrap_node.js:542:3
```

The error is caused by the database sync code not being able to find the pg-migrator executable.

This patch makes it so the search for pg-migrator uses node's `require.resolve` in order to make it much more robust.