### PR TITLE
perf: remove hold account

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "deep-diff": "^0.3.4",
     "eslint-plugin-standard": "^3.0.1",
     "five-bells-condition": "^5.0.1",
-    "five-bells-shared": "23.0.0",
+    "five-bells-shared": "25.0.0",
     "jsonwebtoken": "^7.3.0",
     "knex": "^0.12.9",
     "koa": "^2.2.0",

--- a/src/lib/holds.js
+++ b/src/lib/holds.js
@@ -34,7 +34,6 @@ function holdFunds (transfer, transaction) {
   return Promise.all(transfer.debits.map((debit) => {
     return Promise.all([
       adjustBalance(debit.account, -debit.amount, transaction),
-      adjustBalance('hold', debit.amount, transaction),
       insertEntryByName(debit.account, transfer.id, transaction)
     ])
   }))
@@ -43,7 +42,6 @@ function holdFunds (transfer, transaction) {
 function disburseFunds (transfer, transaction) {
   return Promise.all(transfer.credits.map((credit) => {
     return Promise.all([
-      adjustBalance('hold', -credit.amount, transaction),
       adjustBalance(credit.account, credit.amount, transaction),
       insertEntryByName(credit.account, transfer.id, transaction)
     ])
@@ -53,7 +51,6 @@ function disburseFunds (transfer, transaction) {
 function returnHeldFunds (transfer, transaction) {
   return Promise.all(transfer.debits.map((debit) => {
     return Promise.all([
-      adjustBalance('hold', -debit.amount, transaction),
       adjustBalance(debit.account, debit.amount, transaction),
       insertEntryByName(debit.account, transfer.id, transaction)
     ])

--- a/src/lib/seed-db.js
+++ b/src/lib/seed-db.js
@@ -5,16 +5,8 @@ const upsertAccount = require('../models/db/accounts').upsertAccount
 const insertAccounts = require('../models/accounts').insertAccounts
 
 module.exports = async function (config) {
-  await setupHoldAccount()
   if (config.get('default_admin')) {
     await setupAdminAccount(config.get('default_admin'))
-  }
-}
-
-async function setupHoldAccount () {
-  const holdAccount = await getAccount('hold')
-  if (!holdAccount) {
-    await upsertAccount({name: 'hold', minimum_allowed_balance: '0', balance: '0'})
   }
 }
 

--- a/test/accountSpec.js
+++ b/test/accountSpec.js
@@ -39,7 +39,6 @@ describe('Accounts', function () {
     // Define example data
     this.exampleAccounts = _.cloneDeep(require('./data/accounts'))
     this.adminAccount = this.exampleAccounts.admin
-    this.holdAccount = this.exampleAccounts.hold
     this.existingAccount = this.exampleAccounts.alice
     this.existingAccount2 = this.exampleAccounts.bob
     this.traderAccount = this.exampleAccounts.trader
@@ -56,7 +55,6 @@ describe('Accounts', function () {
     // Store some example data
     await dbHelper.addAccounts([
       this.adminAccount,
-      this.holdAccount,
       this.existingAccount,
       this.existingAccount2,
       this.traderAccount,
@@ -67,14 +65,12 @@ describe('Accounts', function () {
   describe('GET /accounts', function () {
     it('should return 200', async function () {
       const account1 = this.adminAccount
-      const account2 = this.holdAccount
       const account3 = this.existingAccount
       const account4 = this.existingAccount2
       const account5 = this.traderAccount
       const account6 = this.disabledAccount
       // Passwords are not returned
       delete account1.password
-      delete account2.password
       delete account3.password
       delete account4.password
       delete account5.password
@@ -86,7 +82,7 @@ describe('Accounts', function () {
           const sortedResponse = _.sortBy(res.body, (account) => {
             return account.name
           })
-          const sortedAccounts = _.sortBy([account1, account2, account3, account4, account5, account6], (account) => {
+          const sortedAccounts = _.sortBy([account1, account3, account4, account5, account6], (account) => {
             return account.name
           })
           expect(sortedResponse).to.deep.equal(sortedAccounts)

--- a/test/data/accounts.json
+++ b/test/data/accounts.json
@@ -47,13 +47,6 @@
     "is_disabled": false,
     "minimum_allowed_balance": "0"
   },
-  "hold": {
-    "id": "http://localhost/accounts/hold",
-    "name": "hold",
-    "balance": "0",
-    "is_disabled": false,
-    "minimum_allowed_balance": "0"
-  },
   "trader": {
     "id": "http://localhost/accounts/trader",
     "name": "trader",

--- a/test/fulfillmentSpec.js
+++ b/test/fulfillmentSpec.js
@@ -14,9 +14,6 @@ const accounts = require('./data/accounts')
 const validator = require('./helpers/validator')
 const getAccount = require('../src/models/db/accounts').getAccount
 
-// see test/mocha.opts and test/helpers/dbFailureMock.js
-const dbFailureMock = require('../src/models/db/utils')
-
 const START_DATE = 1434412800000 // June 16, 2015 00:00:00 GMT
 
 describe('GET /fulfillment', function () {
@@ -154,8 +151,6 @@ describe('GET /fulfillment', function () {
   async function returnFulfillment () {
     const transfer = this.preparedTransfer
 
-    await dbHelper.setHoldBalance(10)
-
     await this.request()
       .put(transfer.id + '/fulfillment')
       .auth('admin', 'admin')
@@ -173,53 +168,6 @@ describe('GET /fulfillment', function () {
   }
 
   it('should return a fulfillment', returnFulfillment)
-
-  describe('when hold account is busy', function () {
-    const ARGS_EXPECTED = {
-      '0': 'UPDATE "L_ACCOUNTS" SET "BALANCE" = "BALANCE" + ? WHERE "NAME" = ?',
-      '1': [ -10, 'hold' ]
-    }
-
-    beforeEach(function () {
-      dbFailureMock.timesQueryShouldFail[JSON.stringify(ARGS_EXPECTED)] = 3
-    })
-
-    afterEach(function () {
-      const timesLeft = dbFailureMock.timesQueryShouldFail[JSON.stringify(ARGS_EXPECTED)]
-      dbFailureMock.timesQueryShouldFail[JSON.stringify(ARGS_EXPECTED)] = 0
-      expect(timesLeft).to.equal(0)
-    })
-
-    it('should return a fulfillment', returnFulfillment)
-
-    it('should give up if retrying takes too long', async function () {
-      dbFailureMock.timesQueryShouldFail[JSON.stringify(ARGS_EXPECTED)] = 1000000
-      try {
-        const transfer = this.preparedTransfer
-
-        await dbHelper.setHoldBalance(10)
-
-        await this.request()
-          .put(transfer.id + '/fulfillment')
-          .auth('admin', 'admin')
-          .send(this.executionConditionFulfillment)
-          .expect(503)
-          .expect('Database is busy')
-
-        await this.request()
-          .get(transfer.id + '/fulfillment')
-          .auth('admin', 'admin')
-          .expect(404)
-          .expect('{"id":"MissingFulfillmentError","message":"This transfer has not yet been fulfilled"}')
-      } catch (e) {
-        dbFailureMock.timesQueryShouldFail[JSON.stringify(ARGS_EXPECTED)] = 0
-        throw e
-      }
-      const timesLeft = dbFailureMock.timesQueryShouldFail[JSON.stringify(ARGS_EXPECTED)]
-      dbFailureMock.timesQueryShouldFail[JSON.stringify(ARGS_EXPECTED)] = 0
-      expect(timesLeft).to.be.above(0)
-    })
-  })
 
   /* put fulfillments */
   /* Fulfillment errors */
@@ -460,11 +408,9 @@ describe('PUT /fulfillment', function () {
     ])
 
     // Check balances
-    const holdAccount = await getAccount('hold')
     const senderAccount = await getAccount('alice')
     const receiverAccount = await getAccount('bob')
 
-    expect(holdAccount.balance).to.equal(0)
     expect(senderAccount.balance).to.equal(90)
     expect(receiverAccount.balance).to.equal(10)
   })

--- a/test/helpers/db.js
+++ b/test/helpers/db.js
@@ -3,7 +3,6 @@
 const db = require('../../src/lib/db')
 const insertTransfers = require('../../src/models/transfers').insertTransfers
 const insertAccounts = require('../../src/models/accounts').insertAccounts
-const setBalance = require('../../src/models/accounts').setBalance
 const insertFulfillments = require('../../src/models/db/fulfillments')
   .insertFulfillments
 
@@ -21,10 +20,6 @@ exports.init = async function () {
 
 exports.clean = async function () {
   await db.truncateTables()
-}
-
-exports.setHoldBalance = async function (balance) {
-  await setBalance('hold', balance)
 }
 
 exports.addAccounts = async function (accounts) {

--- a/test/notificationSpec.js
+++ b/test/notificationSpec.js
@@ -36,7 +36,6 @@ describe('Notifications', function () {
     // Define example data
     this.exampleAccounts = _.cloneDeep(require('./data/accounts'))
     this.adminAccount = this.exampleAccounts.admin
-    this.holdAccount = this.exampleAccounts.hold
     this.existingAccount = this.exampleAccounts.alice
     this.existingAccount2 = this.exampleAccounts.bob
     this.existingAccount3 = this.exampleAccounts.candice
@@ -59,7 +58,6 @@ describe('Notifications', function () {
     // Store some example data
     await dbHelper.addAccounts([
       this.adminAccount,
-      this.holdAccount,
       this.existingAccount,
       this.existingAccount2,
       this.existingAccount3,


### PR DESCRIPTION
The hold account no longer serves any useful purpose, but it does create a major bottleneck, because the database has to constantly lock the row containing the hold account.