### PR TITLE
build: run npm install during docker build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+node_modules
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,11 @@
-FROM node:7-slim
+FROM node:7.10
 
 RUN mkdir -p /usr/src/app
 WORKDIR /usr/src/app
 
 COPY . /usr/src/app
+
+RUN npm install
 
 EXPOSE 3000
 


### PR DESCRIPTION
The previous workflow of building the docker image (i.e. 1) npm install, 2) docker build ... ) only worked if the host node version is the same as the one used inside the docker container (otherwise, when starting the app inside the container, node is complaining that native dependencies were compiled for a different node version). This commit fixes this issue by running npm install during the docker build, thereby compiling all dependencies for the node version used by the container.